### PR TITLE
Make scrypt (C++ binding) optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+try {
+  module.exports = require('./node')
+} catch (e) {
+  module.exports = require('./js')
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scrypt.js",
   "version": "0.2.1",
   "description": "Scrypt in Node.js and in the browser. Fast & simple.",
-  "main": "node.js",
+  "main": "index.js",
   "scripts": {
     "lint": "standard",
     "test": "tape ./test/index.js"
@@ -20,7 +20,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "scryptsy": "^1.2.1",
+    "scryptsy": "^1.2.1"
+  },
+  "optionalDependencies": {
     "scrypt": "^6.0.2"
   },
   "browser": "js.js",

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,14 @@
 const tape = require('tape')
+const scrypt = require('../index')
 const scryptJS = require('../js')
 const scryptNode = require('../node')
+
+tape('Auto-detected', function (t) {
+  t.test('basic', function (st) {
+    st.deepEqual(scrypt(Buffer.from('key'), Buffer.from('salt'), 1024, 256, 4, 16), Buffer.from('fcc68e0894929cb761fadd8990e0946b', 'hex'))
+    st.end()
+  })
+})
 
 tape('Javascript', function (t) {
   t.test('basic', function (st) {


### PR DESCRIPTION
Hi, please consider this PR to make the scrypt binary an optional dependency.   

With this change an `npm install` will succeed even scrypt fails to build on the local host; in this case the pure JS version (scryptsy) will be used on both the browser and on node.

The "load specific version" will still fail if the demanded version is not present; however, the failure will occur at the time of the `require` rather than during `npm install`.
```
var scrypt = require('scrypt.js) // pure JavaScript (will ALWAYS succeed, might return pure JS on node)
var scrypt = require('scrypt.js/js') // pure JavaScript (will ALWAYS succeed)
var scrypt = require('scrypt.js/node') // C on Node (will throw an exception if scrypt not installed)
```



