### PR TITLE
Turn this library into a scryptsy wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # scrypt.js
 
-This purpose of this library is to provide a single interface to both a C and a pure Javascript based scrypt implementation.
-Supports browserify and will select the best option when running under Node or in the browser.
+This purpose of this library was to provide a single interface to both a C and a pure Javascript based scrypt implementation, support browserify and select the best option when running under Node or in the browser.
 
-It is using the following two underlying implementations:
-- [scryptsy](https://github.com/cryptocoinjs/scryptsy) for the pure Javascript implementation
-- [scrypt](https://www.npmjs.com/package/scrypt) for the C version
+This library is not maintained anymore, and it's just a wrapper around [scryptsy](https://github.com/cryptocoinjs/scryptsy) for backwards compatibility.
 
 It only supports hashing. Doesn't offer an async option and doesn't implement the HMAC format. If you are looking for those,
 please use the Node `scrypt` library.
@@ -25,10 +22,6 @@ There is only one method returned for hashing using scrypt. All parameters are m
 ```js
 // Load default implementation
 var scrypt = require('scrypt.js')
-
-// Load specific version
-var scrypt = require('scrypt.js/js') // pure Javascript
-var scrypt = require('scrypt.js/node') // C on Node
 
 scrypt(key, salt, n, r, p, dklen, progressCb) // returns Buffer
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ workflows:
       - node-v6
       - node-v8
       - node-v10
+      - node-v12
 
 version: 2.1
 jobs:
@@ -45,3 +46,7 @@ jobs:
     <<: *node-base
     docker:
       - image: circleci/node:10
+  node-v12:
+    <<: *node-base
+    docker:
+      - image: circleci/node:12

--- a/index.js
+++ b/index.js
@@ -1,5 +1,1 @@
-try {
-  module.exports = require('./node')
-} catch (e) {
-  module.exports = require('./js')
-}
+module.exports = require('./js')

--- a/node.js
+++ b/node.js
@@ -1,7 +1,0 @@
-var scrypt = require('scrypt')
-
-function hash (key, salt, n, r, p, dklen, progressCb) {
-  return scrypt.hashSync(key, { N: n, r: r, p: p }, dklen, salt)
-}
-
-module.exports = hash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrypt.js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Scrypt in Node.js and in the browser. Fast & simple.",
   "main": "index.js",
   "scripts": {
@@ -21,9 +21,6 @@
   "license": "MIT",
   "dependencies": {
     "scryptsy": "^1.2.1"
-  },
-  "optionalDependencies": {
-    "scrypt": "^6.0.2"
   },
   "browser": "js.js",
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,6 @@
 const tape = require('tape')
 const scrypt = require('../index')
 const scryptJS = require('../js')
-const scryptNode = require('../node')
 
 tape('Auto-detected', function (t) {
   t.test('basic', function (st) {
@@ -13,13 +12,6 @@ tape('Auto-detected', function (t) {
 tape('Javascript', function (t) {
   t.test('basic', function (st) {
     st.deepEqual(scryptJS(Buffer.from('key'), Buffer.from('salt'), 1024, 256, 4, 16), Buffer.from('fcc68e0894929cb761fadd8990e0946b', 'hex'))
-    st.end()
-  })
-})
-
-tape('Node', function (t) {
-  t.test('basic', function (st) {
-    st.deepEqual(scryptNode(Buffer.from('key'), Buffer.from('salt'), 1024, 256, 4, 16), Buffer.from('fcc68e0894929cb761fadd8990e0946b', 'hex'))
     st.end()
   })
 })


### PR DESCRIPTION
IFAIK this library isn't maintained anymore, but it's still being used by most javascript-based Ethereum projects. This is a problem, as it doesn't support node 12. 

`scrypt`, one of this library's dependencies is deprecated, so it won't support node 12.

This PR turns this library into a simple scryptsy wrapper, to be published as a patch version. This way most projects will start using this version and get support for node 12. Releasing it this way can have a performance impact of some users, but I believe that would be a better situation than the current one (i.e. people with node 12 not being able to install most things).

I will prepare a similar PR for 0.2.x, as many projects still use that version.