### PR TITLE
Turn this library into a scryptsy wrapper (0.2.x version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # scrypt.js
 
-This purpose of this library is to provide a single interface to both a C and a pure Javascript based scrypt implementation.
+This purpose of this library is to provide a single interface to both a Node's and a pure Javascript based scrypt implementation.
 Supports browserify and will select the best option when running under Node or in the browser.
 
 It is using the following two underlying implementations:
 - [scryptsy](https://github.com/cryptocoinjs/scryptsy) for the pure Javascript implementation
-- [scrypt](https://www.npmjs.com/package/scrypt) for the C version
+- [Node's native implementation](https://nodejs.org/api/crypto.html#crypto_crypto_scryptsync_password_salt_keylen_options) avialable in Node v10.5.0+
 
-It only supports hashing. Doesn't offer an async option and doesn't implement the HMAC format. If you are looking for those,
-please use the Node `scrypt` library.
+It only supports hashing. Doesn't offer an async option and doesn't implement the HMAC format.
 
 ## API
 
@@ -28,7 +27,7 @@ var scrypt = require('scrypt.js')
 
 // Load specific version
 var scrypt = require('scrypt.js/js') // pure Javascript
-var scrypt = require('scrypt.js/node') // C on Node
+var scrypt = require('scrypt.js/node') // Node's native implementation if available, Javascript implementation otherwise
 
 scrypt(key, salt, n, r, p, dklen, progressCb) // returns Buffer
 ```

--- a/node.js
+++ b/node.js
@@ -1,7 +1,12 @@
-var scrypt = require('scrypt')
+const crypto = require('crypto')
 
 function hash (key, salt, n, r, p, dklen, progressCb) {
-  return scrypt.hashSync(key, { N: n, r: r, p: p }, dklen, salt)
+  const maxmem = 2 * 128 * n * r // See Node's doc for an explanation
+  return crypto.scryptSync(key, salt, dklen, { N: n, r, p, maxmem })
 }
 
-module.exports = hash
+if (crypto.scryptSync === undefined) {
+  module.exports = require('./js')
+} else {
+  module.exports = hash
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrypt.js",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Scrypt in Node.js and in the browser. Fast & simple.",
   "main": "node.js",
   "scripts": {
@@ -20,8 +20,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "scryptsy": "^1.2.1",
-    "scrypt": "^6.0.2"
+    "scryptsy": "^1.2.1"
   },
   "browser": "js.js",
   "devDependencies": {


### PR DESCRIPTION
This is the 0.2.x version of #6.

It has to be merged into https://github.com/axic/scrypt.js/tree/v0.2.1, but github doesn't support creating PRs with a tag as base branch. 

If you create a branch, I can update the PR, and should be mergeable then.