### PR TITLE
Use Node's scrypt implementation if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # scrypt.js
 
-This purpose of this library is to provide a single interface to both a C and a pure Javascript based scrypt implementation.
+This purpose of this library is to provide a single interface to both Node's and a pure Javascript based scrypt implementation.
 Supports browserify and will select the best option when running under Node or in the browser.
 
 It is using the following two underlying implementations:
 - [scryptsy](https://github.com/cryptocoinjs/scryptsy) for the pure Javascript implementation
-- [scrypt](https://www.npmjs.com/package/scrypt) for the C version
+- [Node's native implementation](https://nodejs.org/api/crypto.html#crypto_crypto_scryptsync_password_salt_keylen_options) avialable in Node v10.5.0+
 
-It only supports hashing. Doesn't offer an async option and doesn't implement the HMAC format. If you are looking for those,
-please use the Node `scrypt` library.
+It only supports hashing. Doesn't offer an async option and doesn't implement the HMAC format.
 
 ## API
 
@@ -28,7 +27,7 @@ var scrypt = require('scrypt.js')
 
 // Load specific version
 var scrypt = require('scrypt.js/js') // pure Javascript
-var scrypt = require('scrypt.js/node') // C on Node
+var scrypt = require('scrypt.js/node') // Node's native implementation if available, Javascript implementation otherwise
 
 scrypt(key, salt, n, r, p, dklen, progressCb) // returns Buffer
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -2,9 +2,10 @@ workflows:
   version: 2.1
   node-multi-build:
     jobs:
-      - node-v6
       - node-v8
       - node-v10
+      - node-v11
+      - node-v12
 
 version: 2.1
 jobs:
@@ -33,10 +34,6 @@ jobs:
           paths:
             - ./node_modules
 
-  node-v6:
-    <<: *node-base
-    docker:
-      - image: circleci/node:6
   node-v8:
     <<: *node-base
     docker:
@@ -45,3 +42,11 @@ jobs:
     <<: *node-base
     docker:
       - image: circleci/node:10
+  node-v11:
+    <<: *node-base
+    docker:
+      - image: circleci/node:11
+  node-v12:
+    <<: *node-base
+    docker:
+      - image: circleci/node:12

--- a/index.js
+++ b/index.js
@@ -1,5 +1,0 @@
-try {
-  module.exports = require('./node')
-} catch (e) {
-  module.exports = require('./js')
-}

--- a/node.js
+++ b/node.js
@@ -1,13 +1,12 @@
-const crypto = require("crypto");
+const crypto = require('crypto')
+
+function hash (key, salt, n, r, p, dklen, progressCb) {
+  const maxmem = 2 * 128 * n * r // See Node's doc for an explanation
+  return crypto.scryptSync(key, salt, dklen, { N: n, r, p, maxmem })
+}
 
 if (crypto.scryptSync === undefined) {
-  module.exports = require("./js");
-  return
+  module.exports = require('./js')
+} else {
+  module.exports = hash
 }
-
-function hash(key, salt, n, r, p, dklen, progressCb) {
-  const maxmem = 2 * 128 * n * r; // See Node's doc for an explanation
-  return crypto.scryptSync(key, salt, dklen, { N: n, r, p, maxmem });
-}
-
-module.exports = hash;

--- a/node.js
+++ b/node.js
@@ -1,7 +1,13 @@
-var scrypt = require('scrypt')
+const crypto = require("crypto");
 
-function hash (key, salt, n, r, p, dklen, progressCb) {
-  return scrypt.hashSync(key, { N: n, r: r, p: p }, dklen, salt)
+if (crypto.scryptSync === undefined) {
+  module.exports = require("./js");
+  return
 }
 
-module.exports = hash
+function hash(key, salt, n, r, p, dklen, progressCb) {
+  const maxmem = 2 * 128 * n * r; // See Node's doc for an explanation
+  return crypto.scryptSync(key, salt, dklen, { N: n, r, p, maxmem });
+}
+
+module.exports = hash;

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   "dependencies": {
     "scryptsy": "^1.2.1"
   },
-  "optionalDependencies": {
-    "scrypt": "^6.0.2"
-  },
   "browser": "js.js",
   "devDependencies": {
     "standard": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scrypt.js",
   "version": "0.3.0",
   "description": "Scrypt in Node.js and in the browser. Fast & simple.",
-  "main": "index.js",
+  "main": "node.js",
   "scripts": {
     "lint": "standard",
     "test": "tape ./test/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrypt.js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Scrypt in Node.js and in the browser. Fast & simple.",
   "main": "node.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,14 +1,6 @@
 const tape = require('tape')
-const scrypt = require('../index')
 const scryptJS = require('../js')
 const scryptNode = require('../node')
-
-tape('Auto-detected', function (t) {
-  t.test('basic', function (st) {
-    st.deepEqual(scrypt(Buffer.from('key'), Buffer.from('salt'), 1024, 256, 4, 16), Buffer.from('fcc68e0894929cb761fadd8990e0946b', 'hex'))
-    st.end()
-  })
-})
 
 tape('Javascript', function (t) {
   t.test('basic', function (st) {


### PR DESCRIPTION
This PR is a replacement of #6. Removes the dependency on `scrypt` and replaces it with Node's native implementation. 

This PR also deletes the `index.js` file, as I understand it was introduced to fallback to the js implementation when `optionalDependency` threw when required. The fallback now belongs to `node.js`.

Finally, it bumps the version to `0.3.1`.

